### PR TITLE
Fix concatenation of resource name with query parameters

### DIFF
--- a/Sources/SwiftyHawk/HawkClient.swift
+++ b/Sources/SwiftyHawk/HawkClient.swift
@@ -56,7 +56,10 @@ public extension Hawk {
                 throw Error.couldNotParsePortFromURI
             }
             let timestamp = timestamp ?? Date().timeIntervalSince1970
-            let resource = uri.path + (uri.query ?? "")
+            var resource = uri.path
+            if let query = uri.query {
+                resource += "?\(query)"
+            }
             guard let mac = try Hawk.Crypto.calculateMac(type: "header",
                                                          credentials: credentials,
                                                          resource: resource,

--- a/Tests/SwiftyHawkTests/HawkClientTests.swift
+++ b/Tests/SwiftyHawkTests/HawkClientTests.swift
@@ -90,5 +90,24 @@ class HawkClientTests: XCTestCase {
         
         XCTAssertEqual(headerResult?.headerValue, "Hawk id=\"exqbZWtykFZIh2D7cXi9dA\", ts=\"1368996800\", nonce=\"3yuYCD4Z\", hash=\"neQFHgYKl/jFqDINrC21uLS0gkFglTz789rzcSr7HYU=\", mac=\"2sttHCQJG9ejj1x7eCi35FP23Miu9VtlaUgwk68DTpM=\", app=\"wn6yzHGe5TLaT-fvOPbAyQ\"")
     }
+
+    func testGetRequestWithURLParametersShouldReturnValidAuthorizationHeader() {
+        let credentials = Hawk.Credentials(id: "dh37fgj492je",
+                                           key: "werxhqb98rpaxn39848xrunpaw3489ruxnpa98w4rxn",
+                                           algoritm: .sha256)
+
+        guard let headerResult = try? Hawk.Client.header(uri: "http://example.com:8000/resource/1?b=1&a=2",
+                                                         method: "GET",
+                                                         credentials: credentials,
+                                                         timestamp: 1353832234,
+                                                         nonce: "j4h3g2",
+                                                         ext: "some-app-ext-data")
+        else {
+            XCTFail("Failed to create header")
+            return
+        }
+
+        XCTAssertEqual(headerResult?.headerValue, "Hawk id=\"dh37fgj492je\", ts=\"1353832234\", nonce=\"j4h3g2\", ext=\"some-app-ext-data\", mac=\"6R4rV5iE+NPoym+WwjeHzjAGXUtLNIxmo1vpMofpLAE=\"")
+    }
     
 }


### PR DESCRIPTION
This should fix Issue #1